### PR TITLE
Fix name_regexp to allow upercase policy on DNS name

### DIFF
--- a/slam/slam_core/static/core/index.js
+++ b/slam/slam_core/static/core/index.js
@@ -47,7 +47,7 @@ class HostViewListener {
         var mac_address = $(HARDWARE_CTRL_VIEW.view.mac_address).val();
         var mac_address_regex = new RegExp('([0-9A-F][0-9A-F]:){5}([0-9A-F][0-9A-F])');
 
-        var name_regex = new RegExp("^(([a-z0-9-_\.])*)*$");
+        var name_regex = new RegExp("^(([a-zA-Z0-9-_\.])*)*$");
 
         this.hostname = hostname;
         this.domain = domain;


### PR DESCRIPTION
This PR allow upercase value on dns name. This fix issue #11 